### PR TITLE
Add CLI ROM argument and fix test

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,20 +35,18 @@ A Nintendo Entertainment System (NES) emulator written in Rust. This project aim
 
 ### Running
 
-The emulator currently loads a specified `.nes` ROM file and prints its header information.
+The emulator loads a `.nes` ROM file specified on the command line and prints its
+header information.
 
 1.  Ensure you have a `.nes` ROM file. For initial testing, a simple Mapper 0 ROM is recommended.
-2.  Run the emulator, passing the path to your ROM file as an argument to the `main` function (you will need to modify `src/main.rs` to accept command-line arguments or update the hardcoded path).
+2.  Run the emulator and pass the path to your ROM file:
 
-    Currently, the ROM path is hardcoded in `src/main.rs`. To test:
-    *   Place your test ROM (e.g., `test_rom.nes`) in the project root or update the path in `src/main.rs`.
-    *   Then run:
     ```bash
-    cargo run
+    cargo run -- path/to/your_rom.nes
     ```
     The output will display the parsed header information from the ROM.
 
-    *(Future versions will take the ROM path as a command-line argument and start actual emulation.)*
+    *(Future versions will start actual emulation.)*
 
 ### Running Tests
 

--- a/src/cartridge.rs
+++ b/src/cartridge.rs
@@ -208,7 +208,7 @@ mod tests {
             0x4E, 0x45, 0x53, 0x1A, // "NES\x1A"
             0x02,                   // PRG ROM size: 2 * 16KB
             0x00,                   // CHR ROM size: 0 (implies CHR RAM)
-            0b00010111,             // Flags 6: Mapper lower 1, FourScreen, Trainer, Battery, Vertical
+            0b00011111,             // Flags 6: Mapper lower 1, FourScreen, Trainer, Battery, Vertical
             0b00010000,             // Flags 7: Mapper upper 1
             0x00, 0x00, 0x00, 0x00, 
             0x00, 0x00, 0x00, 0x00

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,8 +5,12 @@ pub mod cpu;
 pub mod ppu;
 
 fn main() {
-    // TODO: make this a command line argument
-    let rom_path = "./minimal.nes"; // Replace with your actual ROM path
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() < 2 {
+        eprintln!("Usage: {} <path_to_rom>", args[0]);
+        std::process::exit(1);
+    }
+    let rom_path = &args[1];
 
     println!("Attempting to load ROM: {}", rom_path);
 


### PR DESCRIPTION
## Summary
- handle ROM path via a command line argument
- correct header flag values in `cartridge` tests
- document running the emulator with the new ROM argument

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684d6167f2e48333b3ab7833c79f55d3